### PR TITLE
Update C# Coding Standards and Naming Conventions.md

### DIFF
--- a/C# Coding Standards and Naming Conventions.md
+++ b/C# Coding Standards and Naming Conventions.md
@@ -109,7 +109,7 @@ UIControl uiControl;
 
 ***Why: consistent with the Microsoft's .NET Framework. Caps would grap visually too much attention.***
 
-#### 8. Do not use Underscores in identifiers. Exception: you can prefix private static variables with an underscore:
+#### 8. Do not use Underscores in identifiers. Exception: you can prefix private fields with an underscore:
 
 ```csharp 
 // Correct


### PR DESCRIPTION
Fixed text for exception in point 8 "Do not use Underscores in identifiers" to include "private fields" instead of "private static variables".